### PR TITLE
ImpactTable.build can return a null value

### DIFF
--- a/olca-core/src/main/java/org/openlca/core/math/DataStructures.java
+++ b/olca-core/src/main/java/org/openlca/core/math/DataStructures.java
@@ -121,6 +121,7 @@ public class DataStructures {
 		if (setup.impactMethod != null) {
 			ImpactTable impacts = ImpactTable.build(
 					mcache, setup.impactMethod.id, data.enviIndex);
+			if(impacts == null) return data;
 			data.impactMatrix = impacts.createMatrix(
 					solver, interpreter);
 			data.impactIndex = impacts.impactIndex;


### PR DESCRIPTION
this prevents a java.lang.NullPointerException when there are no impacts for the current product system