### PR TITLE
Update pom files to allow build with JDK 14

### DIFF
--- a/olca-ecospold-1/pom.xml
+++ b/olca-ecospold-1/pom.xml
@@ -10,4 +10,14 @@
 	<artifactId>olca-ecospold-1</artifactId>
 	<packaging>jar</packaging>
 
+	<dependencies>
+
+		<dependency>
+			<groupId>javax.xml.bind</groupId>
+			<artifactId>jaxb-api</artifactId>
+			<version>2.4.0-b180830.0359</version>
+		</dependency>
+
+	</dependencies>
+
 </project>

--- a/olca-ecospold-2/pom.xml
+++ b/olca-ecospold-2/pom.xml
@@ -10,4 +10,14 @@
 	<artifactId>olca-ecospold-2</artifactId>
 	<packaging>jar</packaging>
 
+	<dependencies>
+
+		<dependency>
+			<groupId>javax.xml.bind</groupId>
+			<artifactId>jaxb-api</artifactId>
+			<version>2.4.0-b180830.0359</version>
+		</dependency>
+
+	</dependencies>
+
 </project>

--- a/olca-geo/pom.xml
+++ b/olca-geo/pom.xml
@@ -18,7 +18,7 @@
 		<repository>
 			<id>osgeo</id>
 			<name>Open Source Geospatial Foundation Repository</name>
-			<url>http://download.osgeo.org/webdav/geotools/</url>
+			<url>https://repo.osgeo.org/repository/release/</url>
 		</repository>
 	</repositories>
 

--- a/olca-ilcd/pom.xml
+++ b/olca-ilcd/pom.xml
@@ -30,6 +30,12 @@
 			<version>1.19</version>
 		</dependency>
 
+		<dependency>
+			<groupId>javax.xml.bind</groupId>
+			<artifactId>jaxb-api</artifactId>
+			<version>2.4.0-b180830.0359</version>
+		</dependency>
+
 	</dependencies>
 
 </project>

--- a/olca-jsonld/pom.xml
+++ b/olca-jsonld/pom.xml
@@ -24,6 +24,12 @@
 			<version>2.2.4</version>
 		</dependency>
 
+		<dependency>
+			<groupId>javax.xml.bind</groupId>
+			<artifactId>jaxb-api</artifactId>
+			<version>2.4.0-b180830.0359</version>
+		</dependency>
+
 	</dependencies>
 
 </project>


### PR DESCRIPTION
JAXB is not available by default with JDK 9+, add a dependency.
Url for geotools is not valid, change it to working url.