### PR TITLE
Fix #26: - Compilation fails for olca-proto module

### DIFF
--- a/olca-proto/pom.xml
+++ b/olca-proto/pom.xml
@@ -113,6 +113,51 @@
 
   <profiles>
     <profile>
+      <id>osx-aarch_64</id>
+      <activation>
+        <os>
+          <name>Mac OS X</name>
+          <family>mac</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.xolstice.maven.plugins</groupId>
+            <artifactId>protobuf-maven-plugin</artifactId>
+            <version>0.6.1</version>
+            <configuration>
+              <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:osx-x86_64</protocArtifact>
+              <pluginId>grpc-java</pluginId>
+              <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:osx-x86_64</pluginArtifact>
+            </configuration>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>compile</goal>
+                  <goal>compile-custom</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>kr.motd.maven</groupId>
+            <artifactId>os-maven-plugin</artifactId>
+            <version>1.7.0</version>
+            <executions>
+              <execution>
+                <phase>initialize</phase>
+                <goals>
+                  <goal>detect</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
       <id>server-app</id>
       <activation>
         <activeByDefault>false</activeByDefault>


### PR DESCRIPTION
This PR solves the issue #26 - Compilation fails for olca-proto module, which is experienced by macOS Apple M1/Arm users. This issue happens due to `os-maven-plugin` used to get the `os.detected.classifier` for installing (protobuf)[https://github.com/protocolbuffers/protobuf] and (grpc-java)[https://github.com/grpc/grpc-java]. These plugins has no support for the osx-aarch_64 classifier, so a new profile is created for these machines pointing to osx-x86_64 classifier. This works because the M1 macs are able to run x86_64 binaries in rosetta compatibility mode.

In the future, if native M1 support comes, this profile must be deleted.

**SCREENSHOTS**
Before:
![Screen Shot 2021-08-24 at 17 50 23](https://user-images.githubusercontent.com/26262620/130648716-095d6c07-2d23-4acb-81dd-f4ab74d16a58.png)

After:
![Screen Shot 2021-08-24 at 17 47 06](https://user-images.githubusercontent.com/26262620/130648279-2ed5da93-6cf7-4da0-8102-601ee9f766a3.png)
