### PR TITLE
json-import: separator independent file name for binary assets

### DIFF
--- a/olca-core/src/main/java/org/openlca/jsonld/JsonStoreReader.java
+++ b/olca-core/src/main/java/org/openlca/jsonld/JsonStoreReader.java
@@ -72,19 +72,15 @@ public interface JsonStoreReader {
 		var json = new String(bytes, StandardCharsets.UTF_8);
 		return new Gson().fromJson(json, JsonElement.class);
 	}
-	
+
 	default List<LibraryLink> getLibraryLinks() {
 		return PackageInfo.readFrom(this).libraries();
 	}
 
-	default String getFileName(String path) {
-		return Paths.get(path).getFileName().toString();
-	}
-	
 	/**
 	 * Get the raw bytes of the JSON or binary file that is stored under the
 	 * given path.
 	 */
 	byte[] getBytes(String path);
-	
+
 }

--- a/olca-core/src/main/java/org/openlca/jsonld/input/JsonImport.java
+++ b/olca-core/src/main/java/org/openlca/jsonld/input/JsonImport.java
@@ -220,8 +220,10 @@ public class JsonImport implements Runnable, EntityResolver {
 			for (var path : reader.getBinFiles(type, refId)) {
 				byte[] data = reader.getBytes(path);
 				if (data == null)
-					return;
-				var name = reader.getFileName(path);
+					continue;
+				var name = fileNameOf(path);
+				if (name == null)
+					continue;
 				if (!dir.exists()) {
 					Files.createDirectories(dir.toPath());
 				}
@@ -232,5 +234,22 @@ public class JsonImport implements Runnable, EntityResolver {
 			var log = LoggerFactory.getLogger(getClass());
 			log.error("failed to import bin files for " + type + ":" + refId, e);
 		}
+	}
+
+	private String fileNameOf(String path) {
+		if (path == null)
+			return null;
+		int lastSep = -1;
+		for (int i = 0; i < path.length(); i++) {
+			char c = path.charAt(i);
+			if (c == '/' || c == '\\') {
+				lastSep = i;
+			}
+		}
+		if (lastSep == -1)
+			return path; // no separator
+		if (lastSep == (path.length() -1))
+			return null; // no file name, should never happen
+		return path.substring(lastSep + 1);
 	}
 }

--- a/olca-git/src/main/java/org/openlca/git/actions/GitStoreReader.java
+++ b/olca-git/src/main/java/org/openlca/git/actions/GitStoreReader.java
@@ -119,11 +119,6 @@ class GitStoreReader implements JsonStoreReader {
 				.map(binary -> ref.getBinariesPath() + "/" + binary)
 				.toList();
 	}
-	
-	@Override
-	public String getFileName(String path) {
-		return path.substring(path.lastIndexOf("/") + 1);
-	}
 
 	@Override
 	public List<String> getFiles(String dir) {


### PR DESCRIPTION
instead of using `Paths.get(...)` by default, we may better always check for slashes and back-slash